### PR TITLE
🐛 Fix GPS required validation and bump version

### DIFF
--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/presenters/JsonFormFragmentPresenter.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/presenters/JsonFormFragmentPresenter.java
@@ -418,10 +418,10 @@ public class JsonFormFragmentPresenter extends
             } else if (childView instanceof Button) {
                 String type = (String) childView.getTag(R.id.type);
                 if (!TextUtils.isEmpty(type) && type.equals(JsonFormConstants.GPS)) {
-                    boolean isRequired = ((childView.getTag(R.id.v_required) instanceof String) || (childView.getTag(R.id.error) instanceof String)
-                            && childView.isEnabled()
-                            && Boolean.parseBoolean((String) childView.getTag(R.id.v_required)));
-                    filled = filled && !isRequired;
+                    boolean isRequired = childView.isEnabled()
+                            && childView.getTag(R.id.v_required) instanceof String
+                            && Boolean.parseBoolean((String) childView.getTag(R.id.v_required));
+                    filled = filled && (!isRequired || GpsFactory.hasValue((Button) childView));
                 }
 
             } else if (childView instanceof MaterialSpinner) {

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/widgets/GpsFactory.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/widgets/GpsFactory.java
@@ -58,11 +58,16 @@ public class GpsFactory implements FormWidgetFactory {
             return new ValidationStatus(true, null, formFragmentView, recordButton);
         }
         Boolean isRequired = Boolean.valueOf((String) recordButton.getTag(R.id.v_required));
-        if (!isRequired || !recordButton.isEnabled()) {
+        if (!isRequired || !recordButton.isEnabled() || hasValue(recordButton)) {
             return new ValidationStatus(true, null, formFragmentView, recordButton);
         }
 
         return new ValidationStatus(false, (String) recordButton.getTag(R.id.error), formFragmentView, recordButton);
+    }
+
+    public static boolean hasValue(Button recordButton) {
+        return recordButton.getTag(R.id.raw_value) instanceof String
+                && StringUtils.isNotBlank((String) recordButton.getTag(R.id.raw_value));
     }
 
     public static String constructString(Location location) {

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/presenters/JsonFormFragmentPresenterRoboElectricTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/presenters/JsonFormFragmentPresenterRoboElectricTest.java
@@ -65,6 +65,7 @@ import com.vijay.jsonwizard.utils.FormUtils;
 import com.vijay.jsonwizard.views.CustomTextView;
 import com.vijay.jsonwizard.views.JsonFormFragmentView;
 import com.vijay.jsonwizard.widgets.NumberSelectorFactory;
+import com.rey.material.widget.Button;
 
 import org.json.JSONArray;
 import org.json.JSONException;
@@ -365,6 +366,21 @@ public class JsonFormFragmentPresenterRoboElectricTest extends BaseTest {
         ((AppCompatSpinner) formFragment.getJsonApi().getFormDataView("step1:user_spinner")).setSelection(1, false);
         boolean newValid = presenter.areFormViewsFilled();
         assertTrue(newValid);
+    }
+
+    @Test
+    public void testAreFormViewsFilledValidatesRequiredGpsAgainstRawValue() {
+        Button gpsButton = mock(Button.class);
+        when(gpsButton.getTag(R.id.type)).thenReturn(JsonFormConstants.GPS);
+        when(gpsButton.getTag(R.id.v_required)).thenReturn("true");
+        when(gpsButton.isEnabled()).thenReturn(true);
+        when(jsonFormActivity.getFormDataViews()).thenReturn(Collections.singletonList(gpsButton));
+
+        when(gpsButton.getTag(R.id.raw_value)).thenReturn("-1.2334 35 0.0 7.8");
+        assertTrue(presenter.areFormViewsFilled());
+
+        when(gpsButton.getTag(R.id.raw_value)).thenReturn("");
+        assertFalse(presenter.areFormViewsFilled());
     }
 
     private void setTextValue(String address, String value) {

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/widgets/GpsFactoryTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/widgets/GpsFactoryTest.java
@@ -15,6 +15,7 @@ import com.vijay.jsonwizard.fragments.JsonFormFragment;
 import com.vijay.jsonwizard.interfaces.CommonListener;
 import com.vijay.jsonwizard.utils.AppExecutors;
 import com.vijay.jsonwizard.utils.FormUtils;
+import com.vijay.jsonwizard.views.JsonFormFragmentView;
 
 import org.apache.commons.lang3.StringUtils;
 import org.json.JSONException;
@@ -178,5 +179,27 @@ public class GpsFactoryTest extends BaseTest {
 
         Mockito.verify(recordButton, Mockito.atLeastOnce())
                 .setTag(Mockito.eq(R.id.raw_value), Mockito.eq(""));
+    }
+
+    @Test
+    public void testValidateReturnsInvalidWhenRequiredGpsHasNoValue() {
+        JsonFormFragmentView formFragmentView = Mockito.mock(JsonFormFragmentView.class);
+        Mockito.doReturn("true").when(recordButton).getTag(R.id.v_required);
+        Mockito.doReturn("Location is required").when(recordButton).getTag(R.id.error);
+        Mockito.doReturn("").when(recordButton).getTag(R.id.raw_value);
+        Mockito.doReturn(true).when(recordButton).isEnabled();
+
+        Assert.assertFalse(GpsFactory.validate(formFragmentView, recordButton).isValid());
+    }
+
+    @Test
+    public void testValidateReturnsValidWhenRequiredGpsHasValue() {
+        JsonFormFragmentView formFragmentView = Mockito.mock(JsonFormFragmentView.class);
+        Mockito.doReturn("true").when(recordButton).getTag(R.id.v_required);
+        Mockito.doReturn("Location is required").when(recordButton).getTag(R.id.error);
+        Mockito.doReturn("-1.2334 35 0.0 7.8").when(recordButton).getTag(R.id.raw_value);
+        Mockito.doReturn(true).when(recordButton).isEnabled();
+
+        Assert.assertTrue(GpsFactory.validate(formFragmentView, recordButton).isValid());
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,5 +1,5 @@
-VERSION_NAME=3.1.9-NACP-SNAPSHOT
-VERSION_CODE=19
+VERSION_NAME=3.1.10-NACP-SNAPSHOT
+VERSION_CODE=20
 GROUP=org.smartregister
 POM_SETTING_DESCRIPTION=OpenSRP Client Native Form Json Wizard
 POM_SETTING_URL=https://github.com/OpenSRP/opensrp-client-native-form


### PR DESCRIPTION
## Summary
- fix GPS `v_required` validation to pass only when the widget has a captured `raw_value`
- align the presenter's form-filled check with the same GPS validation rule
- add regression tests and bump `VERSION_NAME` to `3.1.10-NACP-SNAPSHOT` and `VERSION_CODE` to `20`

## Testing
- `JAVA_HOME="$(/usr/libexec/java_home -v 11)" ./gradlew :android-json-form-wizard:testDebugUnitTest --tests com.vijay.jsonwizard.widgets.GpsFactoryTest --tests com.vijay.jsonwizard.presenters.JsonFormFragmentPresenterRoboElectricTest`
