### PR TITLE
Fix GPS required-field validation error view

### DIFF
--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/customviews/GpsDialog.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/customviews/GpsDialog.java
@@ -123,6 +123,7 @@ public class GpsDialog extends Dialog implements LocationListener, GoogleApiClie
             altitudeTV.setText(String.format(context.getString(R.string.altitude), String.valueOf(location.getAltitude()) + " m"));
             accuracyTV.setText(String.format(context.getString(R.string.accuracy), String.valueOf(location.getAccuracy()) + " m"));
             dataView.setTag(R.id.raw_value, GpsFactory.constructString(location));
+            GpsFactory.clearValidationError(dataView);
         }
     }
 

--- a/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/widgets/GpsFactory.java
+++ b/android-json-form-wizard/src/main/java/com/vijay/jsonwizard/widgets/GpsFactory.java
@@ -11,6 +11,7 @@ import androidx.core.content.ContextCompat;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
+import android.view.ViewParent;
 
 import com.rey.material.util.ViewUtil;
 import com.rey.material.widget.Button;
@@ -55,14 +56,54 @@ public class GpsFactory implements FormWidgetFactory {
     public static ValidationStatus validate(JsonFormFragmentView formFragmentView,
                                             Button recordButton) {
         if (!(recordButton.getTag(R.id.v_required) instanceof String) || !(recordButton.getTag(R.id.error) instanceof String)) {
+            clearValidationError(recordButton);
             return new ValidationStatus(true, null, formFragmentView, recordButton);
         }
         Boolean isRequired = Boolean.valueOf((String) recordButton.getTag(R.id.v_required));
         if (!isRequired || !recordButton.isEnabled() || hasValue(recordButton)) {
+            clearValidationError(recordButton);
             return new ValidationStatus(true, null, formFragmentView, recordButton);
         }
 
-        return new ValidationStatus(false, (String) recordButton.getTag(R.id.error), formFragmentView, recordButton);
+        String errorMessage = (String) recordButton.getTag(R.id.error);
+        showValidationError(recordButton, errorMessage);
+        return new ValidationStatus(false, errorMessage, formFragmentView, recordButton);
+    }
+
+    public static void clearValidationError(View dataView) {
+        updateValidationError(dataView, null);
+    }
+
+    private static void showValidationError(View dataView, String errorMessage) {
+        updateValidationError(dataView, errorMessage);
+    }
+
+    private static void updateValidationError(View dataView, String errorMessage) {
+        TextView errorTextView = getErrorTextView(dataView);
+        if (errorTextView == null) {
+            return;
+        }
+
+        if (StringUtils.isBlank(errorMessage)) {
+            errorTextView.setText(null);
+            errorTextView.setVisibility(View.GONE);
+        } else {
+            errorTextView.setText(errorMessage);
+            errorTextView.setVisibility(View.VISIBLE);
+        }
+    }
+
+    private static TextView getErrorTextView(View dataView) {
+        if (dataView == null) {
+            return null;
+        }
+
+        ViewParent parent = dataView.getParent();
+        if (parent instanceof View) {
+            return ((View) parent).findViewById(R.id.error_textView);
+        }
+
+        return null;
     }
 
     public static boolean hasValue(Button recordButton) {

--- a/android-json-form-wizard/src/main/res/layout/item_gps.xml
+++ b/android-json-form-wizard/src/main/res/layout/item_gps.xml
@@ -60,5 +60,15 @@
             android:text="@string/accuracy" />
     </LinearLayout>
 
+    <com.rey.material.widget.TextView
+        android:id="@+id/error_textView"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="@dimen/default_bottom_margin"
+        android:layout_marginStart="@dimen/inner_components_spacing"
+        android:layout_marginEnd="@dimen/inner_components_spacing"
+        android:textColor="@color/toaster_note_red_icon"
+        android:textSize="@dimen/default_text_size"
+        android:visibility="gone" />
 
 </LinearLayout>

--- a/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/widgets/GpsFactoryTest.java
+++ b/android-json-form-wizard/src/test/java/com/vijay/jsonwizard/widgets/GpsFactoryTest.java
@@ -3,6 +3,7 @@ package com.vijay.jsonwizard.widgets;
 import android.content.Context;
 import android.content.res.Resources;
 import android.view.View;
+import android.widget.LinearLayout;
 
 import com.rey.material.widget.Button;
 import com.rey.material.widget.TextView;
@@ -48,7 +49,7 @@ public class GpsFactoryTest extends BaseTest {
     private CommonListener listener;
 
     @Mock
-    private View rootLayout;
+    private LinearLayout rootLayout;
 
     @Mock
     private TextView latitudeTV;
@@ -61,6 +62,9 @@ public class GpsFactoryTest extends BaseTest {
 
     @Mock
     private TextView accuracyTV;
+
+    @Mock
+    private TextView errorTextView;
 
     @Mock
     private Button recordButton;
@@ -188,8 +192,12 @@ public class GpsFactoryTest extends BaseTest {
         Mockito.doReturn("Location is required").when(recordButton).getTag(R.id.error);
         Mockito.doReturn("").when(recordButton).getTag(R.id.raw_value);
         Mockito.doReturn(true).when(recordButton).isEnabled();
+        Mockito.doReturn(rootLayout).when(recordButton).getParent();
+        Mockito.doReturn(errorTextView).when(rootLayout).findViewById(R.id.error_textView);
 
         Assert.assertFalse(GpsFactory.validate(formFragmentView, recordButton).isValid());
+        Mockito.verify(errorTextView).setText("Location is required");
+        Mockito.verify(errorTextView).setVisibility(View.VISIBLE);
     }
 
     @Test
@@ -199,7 +207,11 @@ public class GpsFactoryTest extends BaseTest {
         Mockito.doReturn("Location is required").when(recordButton).getTag(R.id.error);
         Mockito.doReturn("-1.2334 35 0.0 7.8").when(recordButton).getTag(R.id.raw_value);
         Mockito.doReturn(true).when(recordButton).isEnabled();
+        Mockito.doReturn(rootLayout).when(recordButton).getParent();
+        Mockito.doReturn(errorTextView).when(rootLayout).findViewById(R.id.error_textView);
 
         Assert.assertTrue(GpsFactory.validate(formFragmentView, recordButton).isValid());
+        Mockito.verify(errorTextView).setText(null);
+        Mockito.verify(errorTextView).setVisibility(View.GONE);
     }
 }


### PR DESCRIPTION
## Root cause
GpsFactory validated required GPS fields but the widget layout had no error view and the validation path did not toggle any on-screen message.

## Fix
- added an error TextView to the GPS widget layout
- updated GpsFactory validation to show the configured required-field error and hide it again when the field becomes valid
- cleared the GPS validation error immediately after a successful location capture in GpsDialog
- extended GpsFactoryTest to cover required invalid and valid error-view behavior

## Tests
- export JAVA_HOME=$(/usr/libexec/java_home -v 11) && export PATH="$JAVA_HOME/bin:$PATH" && ./gradlew :android-json-form-wizard:testDebugUnitTest --tests com.vijay.jsonwizard.widgets.GpsFactoryTest